### PR TITLE
Add badges to Hackage, Stackage and Travis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Build Status](https://travis-ci.org/qfpl/tasty-hedgehog.svg?branch=master)](https://travis-ci.org/qfpl/tasty-hedgehog)
+[![tasty-discover-nightly](http://stackage.org/package/tasty-hedgehog/badge/nightly)](http://stackage.org/nightly/package/tasty-hedgehog)
+[![tasty-discover-lts](http://stackage.org/package/tasty-hedgehog/badge/lts)](http://stackage.org/lts/package/tasty-hedgehog)
+[![Hackage Status](https://img.shields.io/hackage/v/tasty-hedgehog.svg)](http://hackage.haskell.org/package/tasty-hedgehog)
 
 # `tasty-hedgehog`
 


### PR DESCRIPTION
Rendered is over [here](https://github.com/lwm/tasty-hedgehog/blob/d069c074e0137a9a39fe692a97f10e70e579132f/README.md).

Useful when passing by and seeing where `tasty-hedgehog` is at.