### PR TITLE
Remove the return of "OK" status message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *#*
 *.swp
+.ghc.environment*
 
 /dist
 /dist-newstyle

--- a/src/Test/Tasty/Hedgehog.hs
+++ b/src/Test/Tasty/Hedgehog.hs
@@ -137,7 +137,7 @@ reportOutput showReplay name report@(Report _ _ status) = do
           else ""
       s ++ replayStr
     GaveUp -> "Gave up"
-    OK -> "OK"
+    OK -> "" -- 'tasty' will print an "OK" for us.
 
 instance T.IsTest HP where
   testOptions =

--- a/tasty-hedgehog.cabal
+++ b/tasty-hedgehog.cabal
@@ -1,5 +1,5 @@
 name:                tasty-hedgehog
-version:             0.2.0.0
+version:             0.2.1.0
 license:             BSD3
 license-file:        LICENCE
 author:              Dave Laing


### PR DESCRIPTION
This is a minor nit to pick but it tidies up the test output.

Unsure about that version bound bump? Since it is not code related but it makes a significant change to the output.