### PR TITLE
Fix testProperty documentation

### DIFF
--- a/src/Test/Tasty/Hedgehog.hs
+++ b/src/Test/Tasty/Hedgehog.hs
@@ -37,7 +37,7 @@ import Hedgehog.Internal.Seed as Seed
 data HP = HP T.TestName Property
   deriving (Typeable)
 
--- | Create a 'Test' from a Hedgehog property
+-- | Create a 'T.TestTree' from a Hedgehog 'Property'.
 testProperty :: T.TestName -> Property -> T.TestTree
 testProperty name prop = T.singleTest name (HP name prop)
 


### PR DESCRIPTION
The Haddock documentation for `testProperty` was actually referencing the Hedgehog [`Test`](https://hackage.haskell.org/package/hedgehog-1.0.2/docs/Hedgehog.html#t:Test) type rather than the Tasty [`TestTree`](https://hackage.haskell.org/package/tasty-1.3.1/docs/Test-Tasty.html#t:TestTree) type.