### PR TITLE
Add function to convert a Hedgehog Group to a Tasty TestTree

### DIFF
--- a/src/Test/Tasty/Hedgehog.hs
+++ b/src/Test/Tasty/Hedgehog.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Test.Tasty.Hedgehog (
     testProperty
+  , fromGroup
   -- * Options you can pass in via tasty
   , HedgehogReplay(..)
   , HedgehogShowReplay(..)
@@ -24,6 +25,7 @@ module Test.Tasty.Hedgehog (
 import Data.Maybe (fromMaybe)
 import Data.Typeable
 
+import qualified Test.Tasty as T
 import qualified Test.Tasty.Providers as T
 import Test.Tasty.Options
 
@@ -40,6 +42,15 @@ data HP = HP T.TestName Property
 -- | Create a 'Test' from a Hedgehog property
 testProperty :: T.TestName -> Property -> T.TestTree
 testProperty name prop = T.singleTest name (HP name prop)
+
+-- | Create a 'T.TestTree' from a Hedgehog 'Group'.
+fromGroup :: Group -> T.TestTree
+fromGroup group =
+    T.testGroup (unGroupName $ groupName group) $
+      map mkTestTree (groupProperties group)
+  where
+    mkTestTree :: (PropertyName, Property) -> T.TestTree
+    mkTestTree (propName, prop) = testProperty (unPropertyName propName) prop
 
 -- | The replay token to use for replaying a previous test run
 newtype HedgehogReplay = HedgehogReplay (Maybe (Size, Seed))


### PR DESCRIPTION
In a project I'm working on, this came in handy for converting a Hedgehog `Group` to a Tasty `TestTree`.

However, I'm not sure if `fromGroup` is a nice name. I was thinking of `testGroup`, but that's already a [function in `tasty`](https://hackage.haskell.org/package/tasty-1.3.1/docs/Test-Tasty.html#v:testGroup) and I didn't want to cause any confusion. 

Any suggestions?