### PR TITLE
Bump tasty upper bound

### DIFF
--- a/tasty-hedgehog.cabal
+++ b/tasty-hedgehog.cabal
@@ -23,7 +23,7 @@ library
   exposed-modules:     Test.Tasty.Hedgehog
   build-depends:       base >= 4.8 && <4.15
                      , tagged >= 0.8 && < 0.9
-                     , tasty >= 0.11 && < 1.4
+                     , tasty >= 0.11 && < 1.5
                      , hedgehog >= 1.0.2 && < 1.0.4
   hs-source-dirs:      src
   ghc-options:         -Wall
@@ -34,7 +34,7 @@ test-suite tasty-hedgehog-tests
   main-is:             Main.hs
   hs-source-dirs:      test
   build-depends:       base >= 4.8 && <4.15
-                     , tasty >= 0.11 && < 1.4
+                     , tasty >= 0.11 && < 1.5
                      , tasty-expected-failure >= 0.11 && < 0.13
                      , hedgehog >= 1.0.2 && < 1.0.4
                      , tasty-hedgehog


### PR DESCRIPTION
I verified that it builds and passes tests with:

```
$ cabal build --enable-tests --constraint 'tasty == 1.4'
$ cabal test --enable-tests --constraint 'tasty == 1.4'
```