### PR TITLE
Allow for different test and property names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /cabal.sandbox.config
 /cabal.project.local
 result
+
+.stack-work/

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ main =
   testGroup "tasty-hedgehog tests"
     [ testProperty
         "reverse involutive"
+        "prop_reverse_involutive"
         prop_reverse_involutive
     ]
 ```
@@ -106,10 +107,12 @@ main =
   testGroup "tasty-hedgehog tests"
     [ testProperty
         "reverse involutive"
+        "prop_reverse_involutive"
         prop_reverse_involutive
     , expectFail $ testProperty
         "badReverse involutive fails"
-         prop_badReverse_involutive
+        "prop_badReverse_involutive"
+        prop_badReverse_involutive
     ]
 ```
 and now running the tests will give you something like this:

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0.0 -- 2022-03-07
 
-* Add `testPropertyNamed` function.
+* Add `testPropertyNamed` function and deprecate `testProperty`.
 
 ## 1.1.0.0 -- 2021-04-03
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Revision history for tasty-hedgehog
 
+## 1.2.0.0 -- 2022-03-07
+
+* Add `testPropertyNamed` function.
+
 ## 1.1.0.0 -- 2021-04-03
 
 * Add fromGroup function
@@ -25,7 +29,7 @@
 ## 0.2.0.0  -- 2018-03-13
 
 * Removes the verbosity option, which was unsupported
-* Fixes a bug in configuration option handling, which 
+* Fixes a bug in configuration option handling, which
   was overwriting use configuration with the defaults.
 
 ## 0.1.0.2  -- 2018-01-22

--- a/src/Test/Tasty/Hedgehog.hs
+++ b/src/Test/Tasty/Hedgehog.hs
@@ -4,8 +4,8 @@
 --
 -- @
 -- testGroup "tasty-hedgehog tests" [
---    testProperty "reverse involutive" prop_reverse_involutive
---  , testProperty "sort idempotent"    prop_sort_idempotent
+--    testPropertyNamed "reverse involutive" "prop_reverse_involutive" prop_reverse_involutive
+--  , testPropertyNamed "sort idempotent"    "prop_sort_idempotent"    prop_sort_idempotent
 --  ]
 -- @
 --
@@ -41,6 +41,7 @@ data HP = HP PropertyName Property
   deriving (Typeable)
 
 -- | Create a 'T.TestTree' from a Hedgehog 'Property'.
+{-# DEPRECATED testProperty "testProperty will cause Hedgehog to provide incorrect instructions for re-checking properties" #-}
 testProperty :: T.TestName -> Property -> T.TestTree
 testProperty name prop = T.singleTest name (HP (PropertyName name) prop)
 

--- a/src/Test/Tasty/Hedgehog.hs
+++ b/src/Test/Tasty/Hedgehog.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Test.Tasty.Hedgehog (
     testProperty
+  , testPropertyNamed
   , fromGroup
   -- * Options you can pass in via tasty
   , HedgehogReplay(..)
@@ -36,12 +37,30 @@ import Hedgehog.Internal.Runner as H
 import Hedgehog.Internal.Report
 import Hedgehog.Internal.Seed as Seed
 
-data HP = HP T.TestName Property
+data HP = HP PropertyName Property
   deriving (Typeable)
 
 -- | Create a 'T.TestTree' from a Hedgehog 'Property'.
 testProperty :: T.TestName -> Property -> T.TestTree
-testProperty name prop = T.singleTest name (HP name prop)
+testProperty name prop = T.singleTest name (HP (PropertyName name) prop)
+
+-- | `testPropertyNamed` @testName propertyName property@ creates a
+-- 'T.TestTree' from @property@ using @testName@ as the displayed
+-- description for the property. The @propertyName@ is used by Hedgehog
+-- when a failure occurs to provide instructions for how to re-run
+-- the property and should normally be set to a string representation
+-- of the @property@ argument.
+--
+-- @
+-- testPropertyNamed
+--  "reverse is involutive"
+--  "prop_reverse_involutive"
+--  prop_reverse_involutive
+-- @
+--
+-- @since 1.2.0.0
+testPropertyNamed :: T.TestName -> PropertyName -> Property -> T.TestTree
+testPropertyNamed name propName prop = T.singleTest name (HP propName prop)
 
 -- | Create a 'T.TestTree' from a Hedgehog 'Group'.
 fromGroup :: Group -> T.TestTree
@@ -142,11 +161,11 @@ reportToProgress config (Report testsDone _ _ status) =
 
 reportOutput :: Bool
              -> UseColor
-             -> String
+             -> PropertyName
              -> Report Result
              -> IO String
 reportOutput showReplay useColor name report = do
-  s <- renderResult useColor (Just (PropertyName name)) report
+  s <- renderResult useColor (Just name) report
   pure $ case reportStatus report of
     Failed fr ->
       let

--- a/tasty-hedgehog.cabal
+++ b/tasty-hedgehog.cabal
@@ -1,5 +1,5 @@
 name:                tasty-hedgehog
-version:             1.1.0.0
+version:             1.2.0.0
 license:             BSD3
 license-file:        LICENCE
 author:              Dave Laing

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -45,5 +45,13 @@ main =
         prop_reverse_involutive
     , expectFail $ testProperty
         "badReverse involutive fails"
-         prop_badReverse_involutive
+        prop_badReverse_involutive
+    , testPropertyNamed
+        "reverse involutive"
+        "prop_reverse_involutive"
+        prop_reverse_involutive
+    , expectFail $ testPropertyNamed
+        "badReverse involutive fails"
+        "prop_badReverse_involutive"
+        prop_badReverse_involutive
     ]


### PR DESCRIPTION
This PR changes `testProperty` to take an extra parameter which allows users to specify a name for the property that's different from the name of the test. Currently the output we get from `hedgehog` for a failing test wrongly instructs users to e.g.:
```
This failure can be reproduced by running:
> recheck (Size 3) (Seed 2994512763059724157 10152725542272428131) badReverse involutive fails
```
This would obviously never work. `hedgehog` seems to encourage/assume that the property name is set to the name of the function that implements it, so this allows users of `tasty-hedgehog` to specify that separately from the test name. With the changes, we can now get the more useful:
```
This failure can be reproduced by running:
> recheck (Size 1) (Seed 3784549250809935497 16296630620216742993) prop_badReverse_involutive
```