### PR TITLE
Add option for coloured output

### DIFF
--- a/src/Test/Tasty/Hedgehog.hs
+++ b/src/Test/Tasty/Hedgehog.hs
@@ -110,7 +110,7 @@ newtype HedgehogUseColor = HedgehogUseColor UseColor
   deriving (Eq, Ord, Show, Typeable)
 
 instance IsOption HedgehogUseColor where 
-  defaultValue = HedgehogUseColor DisableColor
+  defaultValue = HedgehogUseColor EnableColor
   parseValue "DisableColor" = Just (HedgehogUseColor DisableColor)
   parseValue "EnableColor" = Just (HedgehogUseColor EnableColor)
   parseValue _ = Nothing


### PR DESCRIPTION
This adds an option (`HedgehogUseColor`) for controlling whether the `hedgehog` output uses terminal colours or not. a91ef50a65d903d0031c922caf65057e39f6f1eb changed the behaviour of `tasty-hedgehog` which previously used coloured output. I am not sure if that change in behaviour was intentional, but I have kept `DisableColor` as the default for the new `HedgehogUseColor` option which now makes this customisable. 