### PR TITLE
Added color to the report when possible

### DIFF
--- a/src/Test/Tasty/Hedgehog.hs
+++ b/src/Test/Tasty/Hedgehog.hs
@@ -28,7 +28,7 @@ import qualified Test.Tasty.Providers as T
 import Test.Tasty.Options
 
 import Hedgehog
-import Hedgehog.Internal.Config (UseColor(DisableColor))
+import Hedgehog.Internal.Config (UseColor, detectColor)
 import Hedgehog.Internal.Property
 import Hedgehog.Internal.Runner as H
 import Hedgehog.Internal.Report
@@ -130,11 +130,12 @@ reportToProgress config (Report testsDone _ _ status) =
         T.Progress "Shrinking" (ratio (failureShrinks fr) shrinkLimit)
 
 reportOutput :: Bool
+             -> UseColor
              -> String
              -> Report Result
              -> IO String
-reportOutput showReplay name report = do
-  s <- renderResult DisableColor (Just (PropertyName name)) report
+reportOutput showReplay useColor name report = do
+  s <- renderResult useColor (Just (PropertyName name)) report
   pure $ case reportStatus report of
     Failed fr ->
       let
@@ -162,6 +163,7 @@ instance T.IsTest HP where
            ]
 
   run opts (HP name (Property pConfig pTest)) yieldProgress = do
+    useColor <- detectColor
     let
       HedgehogReplay         replay = lookupOption opts
       HedgehogShowReplay showReplay = lookupOption opts
@@ -188,5 +190,5 @@ instance T.IsTest HP where
                  then T.testPassed
                  else T.testFailed
 
-    out <- reportOutput showReplay name report
+    out <- reportOutput showReplay useColor name report
     return $ resultFn out


### PR DESCRIPTION
This is a variant of #43 but this PR relies on the [`detectColor`](https://github.com/hedgehogqa/haskell-hedgehog/blob/06eb4747052a6ef109ab65688fc4d29a39a71c4c/hedgehog/src/Hedgehog/Internal/Config.hs#L88) function from Hedgehog to determine if colour can used for reporting. 

If you have a look at the `detectColor` definition you will notice two things:

 - it can be controlled by an environment variable: `HEDGEHOG_COLOR`
 
 - it explicitly checks if Mark is a user :-). That's the only open-source library I know that is tailored for a user who is not the author!