### PR TITLE
Disable deprecation warnings in tests

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
 {-# language OverloadedStrings #-}
 module Main where
 


### PR DESCRIPTION
(Context: https://github.com/qfpl/tasty-hedgehog/pull/42#issuecomment-1062719801)

Disables deprecation warnings in the test suite, so that no warnings are generated when the tests get compiled.