### PR TITLE
Make `PropertyName` optional and undeprecate `testProperty`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/qfpl/tasty-hedgehog.svg?branch=master)](https://travis-ci.org/qfpl/tasty-hedgehog)
+[![Build Status](https://github.com/qfpl/tasty-hedgehog/actions/workflows/build.yml/badge.svg)](https://github.com/qfpl/tasty-hedgehog/actions/workflows/build.yml)
 [![tasty-discover-nightly](http://stackage.org/package/tasty-hedgehog/badge/nightly)](http://stackage.org/nightly/package/tasty-hedgehog)
 [![tasty-discover-lts](http://stackage.org/package/tasty-hedgehog/badge/lts)](http://stackage.org/lts/package/tasty-hedgehog)
 [![Hackage Status](https://img.shields.io/hackage/v/tasty-hedgehog.svg)](http://hackage.haskell.org/package/tasty-hedgehog)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Revision history for tasty-hedgehog
 
+## 1.3.0.0 -- 2022-08-22
+
+* The `testProperty` function has been undeprecated. Its behaviour differs from that in version `1.1.0.0` and below in that it now passes no `PropertyName` to Hedgehog. Therefore, Hedgehog will render the text `<property>` in its instructions for reproducing test failures, as opposed to whatever description is provided for `testProperty`.
+
 ## 1.2.0.0 -- 2022-03-07
 
 * Add `testPropertyNamed` function and deprecate `testProperty`.

--- a/src/Test/Tasty/Hedgehog.hs
+++ b/src/Test/Tasty/Hedgehog.hs
@@ -37,13 +37,12 @@ import Hedgehog.Internal.Runner as H
 import Hedgehog.Internal.Report
 import Hedgehog.Internal.Seed as Seed
 
-data HP = HP PropertyName Property
+data HP = HP (Maybe PropertyName) Property
   deriving (Typeable)
 
 -- | Create a 'T.TestTree' from a Hedgehog 'Property'.
-{-# DEPRECATED testProperty "testProperty will cause Hedgehog to provide incorrect instructions for re-checking properties, use testPropertyNamed instead." #-}
 testProperty :: T.TestName -> Property -> T.TestTree
-testProperty name prop = T.singleTest name (HP (PropertyName name) prop)
+testProperty name prop = T.singleTest name (HP Nothing prop)
 
 -- | `testPropertyNamed` @testName propertyName property@ creates a
 -- 'T.TestTree' from @property@ using @testName@ as the displayed
@@ -61,7 +60,8 @@ testProperty name prop = T.singleTest name (HP (PropertyName name) prop)
 --
 -- @since 1.2.0.0
 testPropertyNamed :: T.TestName -> PropertyName -> Property -> T.TestTree
-testPropertyNamed name propName prop = T.singleTest name (HP propName prop)
+testPropertyNamed name propName prop =
+  T.singleTest name (HP (Just propName) prop)
 
 -- | Create a 'T.TestTree' from a Hedgehog 'Group'.
 fromGroup :: Group -> T.TestTree
@@ -162,11 +162,11 @@ reportToProgress config (Report testsDone _ _ status) =
 
 reportOutput :: Bool
              -> UseColor
-             -> PropertyName
+             -> Maybe PropertyName
              -> Report Result
              -> IO String
 reportOutput showReplay useColor name report = do
-  s <- renderResult useColor (Just name) report
+  s <- renderResult useColor name report
   pure $ case reportStatus report of
     Failed fr ->
       let

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -Wno-deprecations #-}
 {-# language OverloadedStrings #-}
 module Main where
 


### PR DESCRIPTION
As a result of #58, I reviewed Hedgehog's code and noticed that `PropertyName` is actually optional in https://github.com/hedgehogqa/haskell-hedgehog/blob/f3473dfb4ea817222a09033a90d15bd30ce07f89/hedgehog/src/Hedgehog/Internal/Report.hs#L583-L593 which in turn led me to discover that `renderResult` also accepts a `Maybe PropertyName`.

I have changed the representation of the `HP` constructor to accept a `Maybe PropertyName` instead of a `PropertyName`. Therefore, we can now set that argument to `Nothing` in `testProperty` an undeprecate it, which resolves #58.