### PR TITLE
Allow base-4.17 (GHC 9.4)

### DIFF
--- a/tasty-hedgehog.cabal
+++ b/tasty-hedgehog.cabal
@@ -21,7 +21,7 @@ source-repository   head
 
 library
   exposed-modules:     Test.Tasty.Hedgehog
-  build-depends:       base >= 4.8 && <4.17
+  build-depends:       base >= 4.8 && <4.18
                      , tagged >= 0.8 && < 0.9
                      , tasty >= 0.11 && < 1.5
                      , hedgehog >= 1.0.2 && < 1.1.2
@@ -33,7 +33,7 @@ test-suite tasty-hedgehog-tests
   type:                exitcode-stdio-1.0
   main-is:             Main.hs
   hs-source-dirs:      test
-  build-depends:       base >= 4.8 && <4.17
+  build-depends:       base >= 4.8 && <4.18
                      , tasty >= 0.11 && < 1.5
                      , tasty-expected-failure >= 0.11 && < 0.13
                      , hedgehog >= 1.0.2 && < 1.1.2


### PR DESCRIPTION
Tested using

    cabal test -w ghc-9.4.1 --allow-newer=hedgehog:template-haskell

The allow-newer is not necessary when hedgehogqa/haskell-hedgehog#461 is released. It is already merged.
