### PR TITLE
Use ' not " in suggested command line

### DIFF
--- a/src/Test/Tasty/Hedgehog.hs
+++ b/src/Test/Tasty/Hedgehog.hs
@@ -179,13 +179,13 @@ reportOutput showReplay useColor testName name report = do
         replayStr =
           if showReplay
           then
-            "\nUse '--pattern \"$NF ~ /" ++
+            "\nUse \"--pattern \'$NF ~ /" ++
             testName ++
-            "/\" --hedgehog-replay \"" ++
+            "/\' --hedgehog-replay \'" ++
             skipCompress (SkipToShrink count $ failureShrinkPath fr) ++
             " " ++
             show seed ++
-            "\"' to reproduce from the command-line."
+            "\'\" to reproduce from the command-line."
           else ""
       in
         s ++ replayStr ++ "\n"


### PR DESCRIPTION
as bash will still try to intepolate special characters in `"$NF ~ /foo/"`.