### PR TITLE
Stop testing documentation builds in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,5 +57,3 @@ jobs:
       - name: Run tests
         run: cabal test
 
-      - name: Build documentation
-        run: cabal haddock


### PR DESCRIPTION
It fails often on old GHCs.