### PR TITLE
Support Hedgehog v1.3

### DIFF
--- a/tasty-hedgehog.cabal
+++ b/tasty-hedgehog.cabal
@@ -24,7 +24,7 @@ library
   build-depends:       base >= 4.8 && <4.19
                      , tagged >= 0.8 && < 0.9
                      , tasty >= 0.11 && < 1.5
-                     , hedgehog >= 1.2 && < 1.3
+                     , hedgehog >= 1.2 && < 1.4
   hs-source-dirs:      src
   ghc-options:         -Wall
   default-language:    Haskell2010
@@ -36,7 +36,7 @@ test-suite tasty-hedgehog-tests
   build-depends:       base >= 4.8 && <4.19
                      , tasty >= 0.11 && < 1.5
                      , tasty-expected-failure >= 0.11 && < 0.13
-                     , hedgehog >= 1.2 && < 1.3
+                     , hedgehog >= 1.2 && < 1.4
                      , tasty-hedgehog
   ghc-options:         -Wall
   default-language:    Haskell2010


### PR DESCRIPTION
Bump upper-bounds of hedgehog to include v1.3.

Tested with:
```
cabal test -w ghc-9.6 --constraint='hedgehog==1.3'  
```

Hackage metadata revision would pull this back into stackage nightly :pray: 