### PR TITLE
Support GHC 9.4-9.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,9 @@ jobs:
           - "8.8.3"
           - "8.10.7"
           - "9.0.2"
-          - "9.2.2"
+          - "9.2.8"
+          - "9.4.7"
+          - "9.6.3"
 
     steps:
       - name: Clone repository
@@ -56,4 +58,3 @@ jobs:
 
       - name: Run tests
         run: cabal test
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         ghc-version:
           - "8.0.2"

--- a/tasty-hedgehog.cabal
+++ b/tasty-hedgehog.cabal
@@ -21,7 +21,7 @@ source-repository   head
 
 library
   exposed-modules:     Test.Tasty.Hedgehog
-  build-depends:       base >= 4.8 && <4.19
+  build-depends:       base >= 4.8 && <4.20
                      , tagged >= 0.8 && < 0.9
                      , tasty >= 0.11 && < 1.6
                      , hedgehog >= 1.4 && < 1.5


### PR DESCRIPTION
This PR adds newer GHCs (in the 9.4 to 9.7 range) to the build matrix and makes other changes needed to support those GHC releases.