### PR TITLE
Support ghc 9.12

### DIFF
--- a/tasty-hedgehog.cabal
+++ b/tasty-hedgehog.cabal
@@ -21,7 +21,7 @@ source-repository   head
 
 library
   exposed-modules:     Test.Tasty.Hedgehog
-  build-depends:       base >= 4.8 && <4.21
+  build-depends:       base >= 4.8 && <4.22
                      , tagged >= 0.8 && < 0.9
                      , tasty >= 0.11 && < 1.6
                      , hedgehog >= 1.4 && < 1.6
@@ -33,7 +33,7 @@ test-suite tasty-hedgehog-tests
   type:                exitcode-stdio-1.0
   main-is:             Main.hs
   hs-source-dirs:      test
-  build-depends:       base >= 4.8 && <4.21
+  build-depends:       base >= 4.8 && <4.22
                      , tasty >= 0.11 && < 1.6
                      , tasty-expected-failure >= 0.11 && < 0.13
                      , hedgehog >= 1.4 && < 1.6


### PR DESCRIPTION
Only real change is a bump to the base bounds.

To build with the current Hackage state, need the following `cabal.project` file:
```
packages:
  .

allow-newer:
  , boring:base
  , hashable:base
```

The base bump can be done as a Hackage metadata edit.