### PR TITLE
Use `haskell-actions/setup` instead of `haskell/actions/setup`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install ghc-${{ matrix.ghc-version }}
         id: setup-haskell
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc-version }}
 


### PR DESCRIPTION
`haskell/actions/setup` has been deprecated for some time in favour of `haskell-actions/setup`. It seems that `haskell/actions/setup` fails to install older GHC versions, which caused the checks for #80 to fail. This PR replaces the use of `haskell/actions/setup` with `haskell-actions/setup`.